### PR TITLE
Add simple HTTP API and web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,21 @@ The application supports the following commands:
 # Mark a task as completed (where 1 is the task number)
 ./target/release/rust-todo complete 1
 
+
 # Delete a task (where 1 is the task number)
 ./target/release/rust-todo delete 1
 ```
+
+### Starting the Web Interface
+
+To run the simple Node.js server that serves the React frontend and provides a
+REST API, execute:
+
+```bash
+node server.js
+```
+
+The application will be available at `http://localhost:3000`.
 
 ### Running Tests
 

--- a/server.js
+++ b/server.js
@@ -1,0 +1,111 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const PORT = process.env.PORT || 3000;
+const DATA_FILE = path.join(__dirname, 'data', 'tasks.json');
+
+function readTasks() {
+  try {
+    return JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+function saveTasks(tasks) {
+  fs.mkdirSync(path.dirname(DATA_FILE), { recursive: true });
+  fs.writeFileSync(DATA_FILE, JSON.stringify(tasks, null, 2));
+}
+
+function serveStatic(filePath, res) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.statusCode = 404;
+      res.end('Not found');
+    } else {
+      const ext = path.extname(filePath);
+      const type = ext === '.js' ? 'text/javascript' : 'text/html';
+      res.setHeader('Content-Type', type);
+      res.end(data);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const parsedUrl = url.parse(req.url, true);
+  const method = req.method || 'GET';
+
+  if (parsedUrl.pathname === '/api/tasks' && method === 'GET') {
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(readTasks()));
+    return;
+  }
+
+  if (parsedUrl.pathname === '/api/tasks' && method === 'POST') {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      const { title } = JSON.parse(body || '{}');
+      if (!title) {
+        res.statusCode = 400;
+        res.end('Missing title');
+        return;
+      }
+      const tasks = readTasks();
+      const newTask = { title, completed: false, created_at: new Date().toISOString() };
+      tasks.push(newTask);
+      saveTasks(tasks);
+      res.statusCode = 201;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(newTask));
+    });
+    return;
+  }
+
+  const completeMatch = parsedUrl.pathname.match(/^\/api\/tasks\/(\d+)\/complete$/);
+  if (completeMatch && method === 'POST') {
+    const id = parseInt(completeMatch[1], 10);
+    const tasks = readTasks();
+    if (tasks[id]) {
+      tasks[id].completed = true;
+      saveTasks(tasks);
+      res.statusCode = 204;
+    } else {
+      res.statusCode = 404;
+    }
+    res.end();
+    return;
+  }
+
+  const deleteMatch = parsedUrl.pathname.match(/^\/api\/tasks\/(\d+)$/);
+  if (deleteMatch && method === 'DELETE') {
+    const id = parseInt(deleteMatch[1], 10);
+    const tasks = readTasks();
+    if (tasks[id]) {
+      tasks.splice(id, 1);
+      saveTasks(tasks);
+      res.statusCode = 204;
+    } else {
+      res.statusCode = 404;
+    }
+    res.end();
+    return;
+  }
+
+  // Serve frontend
+  if (parsedUrl.pathname === '/' || parsedUrl.pathname === '/index.html') {
+    return serveStatic(path.join(__dirname, 'index.html'), res);
+  }
+  if (parsedUrl.pathname.startsWith('/src/')) {
+    return serveStatic(path.join(__dirname, parsedUrl.pathname), res);
+  }
+
+  res.statusCode = 404;
+  res.end('Not found');
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CheckCircle2, Circle, Plus, Trash2 } from 'lucide-react';
 
 interface Task {
@@ -11,29 +11,43 @@ function App() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [newTask, setNewTask] = useState('');
 
+  const fetchTasks = () => {
+    fetch('/api/tasks')
+      .then((r) => r.json())
+      .then(setTasks)
+      .catch(() => setTasks([]));
+  };
+
+  useEffect(() => {
+    fetchTasks();
+  }, []);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!newTask.trim()) return;
 
-    setTasks([
-      ...tasks,
-      {
-        title: newTask,
-        completed: false,
-        created_at: new Date().toISOString(),
-      },
-    ]);
-    setNewTask('');
+    fetch('/api/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: newTask }),
+    })
+      .then(() => {
+        setNewTask('');
+        fetchTasks();
+      })
+      .catch(() => {});
   };
 
   const toggleTask = (index: number) => {
-    const newTasks = [...tasks];
-    newTasks[index].completed = !newTasks[index].completed;
-    setTasks(newTasks);
+    fetch(`/api/tasks/${index}/complete`, { method: 'POST' })
+      .then(fetchTasks)
+      .catch(() => {});
   };
 
   const deleteTask = (index: number) => {
-    setTasks(tasks.filter((_, i) => i !== index));
+    fetch(`/api/tasks/${index}`, { method: 'DELETE' })
+      .then(fetchTasks)
+      .catch(() => {});
   };
 
   return (


### PR DESCRIPTION
## Summary
- add a lightweight Node.js server to expose REST endpoints and serve the React app
- update React frontend to fetch data from the new API
- document how to run the web interface

## Testing
- `cargo test` *(fails: failed to download crates)*
- `cargo fmt --check` *(fails: component not installed)*
- `cargo clippy -- -D warnings` *(fails: component not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684444b5dbe4832cb45f92718f395c32